### PR TITLE
Fixed potential memory leak and -v arg

### DIFF
--- a/include/init.h
+++ b/include/init.h
@@ -1,7 +1,7 @@
 #ifndef INIT_H
 #define INIT_H
 #include "control.h"
-void init();
 
-void arg_parse(int argc, char **argv);
+int arg_parse(int argc, char **argv);
+
 #endif

--- a/src/init.c
+++ b/src/init.c
@@ -14,7 +14,7 @@ int arg_parse(int argc, char **argv) {
                     const char *themePath = arg + 8;
 
                     #ifdef _WIN32
-                    printf(stderr, "Error: Custom themes are not supported on Windows\n");
+                    fprintf(stderr, "Error: Custom themes are not supported on Windows\n");
                     return 1;
                     #endif
                     if (themePath && *themePath) {

--- a/src/init.c
+++ b/src/init.c
@@ -1,22 +1,8 @@
 #include "init.h"
 
-
-void init(){
-    initscr(); cbreak(); noecho(); keypad(stdscr, TRUE); init_colors();
-    mode=WRITING_MODE;
-    selStart=-1;
-    selEnd=-1;
-    
-
-    text=malloc(sizeof(char));
-    length=0;
-    statusText=malloc(sizeof(char)*200);
-    fileName = NULL;
-    fileSet = false;
-    set_status_text(":)");
-}
-
-void arg_parse(int argc, char **argv) {
+// -1 = continue
+// >=0 = stop and exit with returned value
+int arg_parse(int argc, char **argv) {
     for (int i = 1; i < argc; i++) {
         char *arg = argv[i];
 
@@ -28,22 +14,22 @@ void arg_parse(int argc, char **argv) {
                     const char *themePath = arg + 8;
 
                     #ifdef _WIN32
-                    printf("Error: Custom themes are not supported on Windows");
-                    exit(1);
+                    printf(stderr, "Error: Custom themes are not supported on Windows\n");
+                    return 1;
                     #endif
                     if (themePath && *themePath) {
                         if(load_theme(themePath)){
-                            printf("Error: Failed to load theme %s\n",themePath);
-                            exit(1);
+                            fprintf(stderr, "Error: Failed to load theme %s\n",themePath);
+                            return 1;
                         }
                     } else {
-                        printf("Error: --theme requires a path\n");
-                        exit(1);
+                        fprintf(stderr, "Error: --theme requires a path\n");
+                        return 1;
                     }
                 }
                 else {
-                    printf("Unknown option: %s\n", arg);
-                    exit(1);
+                    fprintf(stderr, "Unknown option: %s\n", arg);
+                    return 1;
                 }
             }
           
@@ -56,14 +42,14 @@ void arg_parse(int argc, char **argv) {
                                    "please open an issue on GitHub.\n"
                                    "Contributions are always welcome!\n"
                                    "Thanks for using szci!\n");
-                            exit(0);
+                            return 0;
                             break;
                         case 'r':
                             readOnly = true;
                             break;
                         default:
-                            printf("Unknown option: -%c\n", arg[j]);
-                            exit(1);
+                            fprintf(stderr, "Unknown option: -%c\n", arg[j]);
+                            return 1;
                     }
                 }
             }
@@ -113,7 +99,9 @@ void arg_parse(int argc, char **argv) {
             }
         }
         else {
-            printf("Ignoring extra argument: %s\n", arg);
+            fprintf(stderr, "Ignoring extra argument: %s\n", arg);
         }
     }
+
+    return -1;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -4,9 +4,36 @@
 
 
 int main(int argc, char **argv) {
+    // Initialize global variables
+    mode=WRITING_MODE;
+    selStart=-1;
+    selEnd=-1;
+    text=malloc(sizeof(char));
+    if (!text) {
+        fprintf(stderr, "Error: failed to allocate memory on heap for text\n");
+        return 1;
+    }
+    length=0;
+    statusText=malloc(sizeof(char)*200);
+    if (!statusText) {
+        fprintf(stderr, "Error: failed to allocate memory on heap for status text\n");
+        return 1;
+    }
+    fileName = NULL;
+    fileSet = false;
+    set_status_text(":)");
 
-    init();
-    arg_parse(argc,argv);
+    int exit_code = arg_parse(argc, argv);
+    if (exit_code >= 0) {
+      return exit_code;
+    }
+    
+    // Initialize ncurses
+    initscr();
+    cbreak();
+    noecho();
+    keypad(stdscr, TRUE);
+    init_colors();
 
     render();
     while(true){


### PR DESCRIPTION
I removed init() function as it was terrible to debug, I suggest fixing the global variables as these gave me a headache while debugging. init() function is now just at main()

I fixed potential memory leaks by checking if value allocated on heap didnt return NULL pointer as using NULL pointers will cause program to crash unexpectedly.
Also, you used to printf() error messages and logs in arg_parse() e.g. '-v' option, but you printed it on ncurses window (which is not okay, because printf() should not be used while ncurses window is active) and used exit() to exit immediately without closing it which "broke" the terminal. I fixed it now

I checked for memory leaks with valgrind and there are 0 bytes lost, as it was, just with -v option fixed

Oh and also I changed printf(...) error messages to fprintf(stderr, ...) so it prints errors to stderr instead of stdout.

Nice project btw, but global variables are a thing that MUST be changed as it is unsafe and hard to understand. I will try to fix it in next pull requests.